### PR TITLE
Remove changes for various package managers

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -4,7 +4,5 @@
  (foreign_stubs
   (language c)
   (names h3_stubs)
-  (flags
-   (-I/opt/homebrew/include/h3 -I/usr/local/include/h3 -fPIC)))
- (c_library_flags
-  (-lh3 -L/opt/homebrew/lib)))
+  (flags (-fPIC)))
+ (c_library_flags (-lh3)))

--- a/src/h3_stubs.c
+++ b/src/h3_stubs.c
@@ -5,7 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <h3api.h>
+#include <h3/h3api.h>
 
 #include <caml/alloc.h>
 #include <caml/callback.h>


### PR DESCRIPTION
Originally I planned that this should use libh3 from various package managers, but that is sparsely supported, so opam will build the library instead.